### PR TITLE
Fix chppl-tool/src/makefile

### DIFF
--- a/chppl-tool/src/makefile
+++ b/chppl-tool/src/makefile
@@ -8,6 +8,9 @@ OBJDIR   = ./obj
 SOURCES  = $(wildcard *.cpp)
 OBJECTS  = $(addprefix $(OBJDIR)/, $(SOURCES:.cpp=.o))
 
+all:
+.PHONY: all clean
+
 $(TARGET): $(OBJECTS) $(LIBS)
 	$(COMPILER) -o $@ $^ $(LDFRAGS) $(CFLAGS)
 

--- a/chppl-tool/src/makefile
+++ b/chppl-tool/src/makefile
@@ -17,4 +17,5 @@ $(OBJDIR)/%.o: %.cpp
 
 all: clean $(TARGET)
 
-clean: rm -f $(OBJECTS) $(TARGET)
+clean:
+	rm -f $(OBJECTS) $(TARGET)

--- a/chppl-tool/src/makefile
+++ b/chppl-tool/src/makefile
@@ -12,10 +12,9 @@ $(TARGET): $(OBJECTS) $(LIBS)
 	$(COMPILER) -o $@ $^ $(LDFRAGS) $(CFLAGS)
 
 $(OBJDIR)/%.o: %.cpp
-	@[ -d $(OBJDIR) ]
+	@[ -d $(OBJDIR) ] || mkdir -p $(OBJDIR)
 	$(COMPILER) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 
 all: clean $(TARGET)
 
 clean: rm -f $(OBJECTS) $(TARGET)
-


### PR DESCRIPTION
Qiita の記事拝見しました。

```
$ cd chppl-tool/chppl-tool/src
$ make
```

してもコンパイルできないので修正。
- change to create subdirectory `obj',
- fix a bug saying "No rule to make target `rm'"  on "make clean",
- set `all' the default target.
