### PR TITLE
src/makefile: support dependency outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.lo
 *.o
 *.obj
+*.dep
 
 # Precompiled Headers
 *.gch

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 *.exe
 *.out
 *.app
+
+# chppl-tool object directory
+/chppl-tool/src/obj

--- a/chppl-tool/src/makefile
+++ b/chppl-tool/src/makefile
@@ -14,11 +14,12 @@ all:
 $(TARGET): $(OBJECTS) $(LIBS)
 	$(COMPILER) -o $@ $^ $(LDFRAGS) $(CFLAGS)
 
+-include $(OBJDIR)/*.d
 $(OBJDIR)/%.o: %.cpp
 	@[ -d $(OBJDIR) ] || mkdir -p $(OBJDIR)
-	$(COMPILER) $(CFLAGS) $(INCLUDE) -o $@ -c $<
+	$(COMPILER) $(CFLAGS) $(INCLUDE) -MD -MF $(@:.o=.d) -o $@ -c $<
 
-all: clean $(TARGET)
+all: $(TARGET)
 
 clean:
-	rm -f $(OBJECTS) $(TARGET)
+	rm -f $(OBJECTS) $(OBJECTS:.o=.d) $(TARGET)

--- a/chppl-tool/src/makefile
+++ b/chppl-tool/src/makefile
@@ -14,12 +14,12 @@ all:
 $(TARGET): $(OBJECTS) $(LIBS)
 	$(COMPILER) -o $@ $^ $(LDFRAGS) $(CFLAGS)
 
--include $(OBJDIR)/*.d
+-include $(OBJDIR)/*.dep
 $(OBJDIR)/%.o: %.cpp
 	@[ -d $(OBJDIR) ] || mkdir -p $(OBJDIR)
-	$(COMPILER) $(CFLAGS) $(INCLUDE) -MD -MF $(@:.o=.d) -o $@ -c $<
+	$(COMPILER) $(CFLAGS) $(INCLUDE) -MD -MF $(@:.o=.dep) -o $@ -c $<
 
 all: $(TARGET)
 
 clean:
-	rm -f $(OBJECTS) $(OBJECTS:.o=.d) $(TARGET)
+	rm -f $(OBJECTS) $(OBJECTS:.o=.dep) $(TARGET)


### PR DESCRIPTION
毎回 clean してからすべてコンパイルするのは時間が掛かるので、gcc に依存関係ファイル .dep を出力させて、それを元にコンパイルする必要のあるファイルを選択する様に修正。

他に、gitignore: *.dep および /chppl-tool/src/obj を追加。
