### PR TITLE
Lazy connection

### DIFF
--- a/chppl-tool/src/chppl.cpp
+++ b/chppl-tool/src/chppl.cpp
@@ -19,14 +19,15 @@ int main(int argc, char *argv[]) {
     exit(1);
   }
 
-  Cpgsql con = connect_psql();
-
   int query_flag = 0;
 
   std::string argument = argv[1];
   std::string q = query(argument, query_flag, argv, argc);
 
-  PGresult*  res = con.m_ExecSql(q.c_str());
+  std::cerr << "chppl: connecting..." << std::flush;
+  Cpgsql con = connect_psql();
+  PGresult* res = con.m_ExecSql(q.c_str());
+  std::cerr << std::endl;
 
   if (NULL == res) {
     error.error_invalid_args();


### PR DESCRIPTION
接続待ち時間が気になるので:
- `$ chppl help`, `$ chppl list` など接続を必要としない操作では接続しない。
- 接続を待っているあいだ不安になるので `stderr` に接続中の表示を出す。
